### PR TITLE
[DEST-931] Add setting for custom ad asset ID property name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=1.1.3-SNAPSHOT
+VERSION=1.2.0-SNAPSHOT
 
 POM_ARTIFACT_ID=nielsendcr
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -157,7 +157,9 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     }
 
     String contentAssetIdPropertyName =
-        (settings.contentAssetIdPropertyName != null) ? settings.contentAssetIdPropertyName : "assetId";
+        (settings.contentAssetIdPropertyName != null)
+            ? settings.contentAssetIdPropertyName
+            : "assetId";
     int contentAssetId = properties.getInt(contentAssetIdPropertyName, 0);
     contentMetadata.put("assetid", String.valueOf(contentAssetId));
 
@@ -275,7 +277,9 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     }
 
     String contentAssetIdPropertyName =
-        (settings.contentAssetIdPropertyName != null) ? settings.contentAssetIdPropertyName : "contentAssetId";
+        (settings.contentAssetIdPropertyName != null)
+            ? settings.contentAssetIdPropertyName
+            : "contentAssetId";
     int contentAssetId = properties.getInt(contentAssetIdPropertyName, 0);
     adContentMetadata.put("assetid", String.valueOf(contentAssetId));
 
@@ -316,12 +320,12 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
         String program = content.getString("program");
         adContentMetadata.put("program", program);
       }
-  
+
       if (content.containsKey("airdate")) {
         String airdate = content.getString("airdate");
         adContentMetadata.put("airdate", airdate);
       }
-  
+
       fullEpisodeStatus = content.getBoolean("fullEpisode", false);
     }
 

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -250,103 +250,110 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
       @NonNull Map<String, String> mapper)
       throws JSONException {
 
-    JSONObject adContentMetadata = mapSpecialKeys(properties, mapper);
+    Properties contentProperties = new Properties();
+    JSONObject adContentMetadata = new JSONObject(); // initialize to prevent null pointer exception
 
-    if (options.containsKey("pipmode")) {
-      String pipmode = String.valueOf(options.get("pipmode"));
-      adContentMetadata.put("pipmode", pipmode);
-    } else {
-      adContentMetadata.put("pipmode", "false");
-    }
-
-    if (options.containsKey("crossId1")) {
-      String crossId1 = String.valueOf(options.get("crossId1"));
-      adContentMetadata.put("crossId1", crossId1);
-    }
-
-    if (options.containsKey("crossId2")) {
-      String crossId2 = String.valueOf(options.get("crossId2"));
-      adContentMetadata.put("crossId2", crossId2);
-    }
-
-    if (options.containsKey("segB")) {
-      String segB = String.valueOf(options.get("segB"));
-      adContentMetadata.put("segB", segB);
-    }
-
-    if (options.containsKey("segC")) {
-      String segC = String.valueOf(options.get("segC"));
-      adContentMetadata.put("segC", segC);
-    }
-
-    String contentAssetIdPropertyName =
-        (settings.contentAssetIdPropertyName != null)
-            ? settings.contentAssetIdPropertyName
-            : "contentAssetId";
-    int contentAssetId = properties.getInt(contentAssetIdPropertyName, 0);
-    adContentMetadata.put("assetid", String.valueOf(contentAssetId));
-
-    String clientIdPropertyName =
-        (settings.clientIdPropertyName != null) ? settings.clientIdPropertyName : "clientId";
-    String clientId = properties.getString(clientIdPropertyName);
-    if (clientId != null && !clientId.isEmpty()) {
-      adContentMetadata.put("clientid", clientId);
-    }
-
-    String subbrandPropertyName =
-        (settings.subbrandPropertyName != null) ? settings.subbrandPropertyName : "subbrand";
-    String subbrand = properties.getString(subbrandPropertyName);
-    if (subbrand != null && !subbrand.isEmpty()) {
-      adContentMetadata.put("subbrand", subbrand);
-    }
-
-    String lengthPropertyName =
-        (settings.contentLengthPropertyName != null)
-            ? settings.contentLengthPropertyName
-            : "totalLength";
-    if (properties.containsKey(lengthPropertyName)) {
-      int length = properties.getInt(lengthPropertyName, 0);
-      adContentMetadata.put("length", String.valueOf(length));
-    }
-
-    boolean fullEpisodeStatus = false;
-
-    if (properties.containsKey("content") && properties.getValueMap("content") != null) {
+    if (properties.containsKey("content") && !properties.getValueMap("content").isEmpty()) {
       ValueMap content = properties.getValueMap("content");
+      contentProperties.putAll(content);
+    }
 
-      if (content.containsKey("title")) {
-        String title = content.getString("title");
+    if (!contentProperties.isEmpty()) {
+
+      adContentMetadata = mapSpecialKeys(contentProperties, mapper);
+
+      if (options.containsKey("pipmode")) {
+        String pipmode = String.valueOf(options.get("pipmode"));
+        adContentMetadata.put("pipmode", pipmode);
+      } else {
+        adContentMetadata.put("pipmode", "false");
+      }
+
+      if (options.containsKey("crossId1")) {
+        String crossId1 = String.valueOf(options.get("crossId1"));
+        adContentMetadata.put("crossId1", crossId1);
+      }
+
+      if (options.containsKey("crossId2")) {
+        String crossId2 = String.valueOf(options.get("crossId2"));
+        adContentMetadata.put("crossId2", crossId2);
+      }
+
+      if (options.containsKey("segB")) {
+        String segB = String.valueOf(options.get("segB"));
+        adContentMetadata.put("segB", segB);
+      }
+
+      if (options.containsKey("segC")) {
+        String segC = String.valueOf(options.get("segC"));
+        adContentMetadata.put("segC", segC);
+      }
+
+      boolean fullEpisodeStatus = false;
+
+      String contentAssetIdPropertyName =
+          (settings.contentAssetIdPropertyName != null)
+              ? settings.contentAssetIdPropertyName
+              : "contentAssetId";
+      int contentAssetId = contentProperties.getInt(contentAssetIdPropertyName, 0);
+      adContentMetadata.put("assetid", String.valueOf(contentAssetId));
+
+      String clientIdPropertyName =
+          (settings.clientIdPropertyName != null) ? settings.clientIdPropertyName : "clientId";
+      String clientId = contentProperties.getString(clientIdPropertyName);
+      if (clientId != null && !clientId.isEmpty()) {
+        adContentMetadata.put("clientid", clientId);
+      }
+
+      String subbrandPropertyName =
+          (settings.subbrandPropertyName != null) ? settings.subbrandPropertyName : "subbrand";
+      String subbrand = contentProperties.getString(subbrandPropertyName);
+      if (subbrand != null && !subbrand.isEmpty()) {
+        adContentMetadata.put("subbrand", subbrand);
+      }
+
+      String lengthPropertyName =
+          (settings.contentLengthPropertyName != null)
+              ? settings.contentLengthPropertyName
+              : "totalLength";
+      if (contentProperties.containsKey(lengthPropertyName)) {
+        int length = contentProperties.getInt(lengthPropertyName, 0);
+        adContentMetadata.put("length", String.valueOf(length));
+      }
+
+      if (contentProperties.containsKey("title")) {
+        String title = contentProperties.getString("title");
         adContentMetadata.put("title", title);
       }
 
-      if (content.containsKey("program")) {
-        String program = content.getString("program");
+      if (contentProperties.containsKey("program")) {
+        String program = contentProperties.getString("program");
         adContentMetadata.put("program", program);
       }
 
-      if (content.containsKey("airdate")) {
-        String airdate = content.getString("airdate");
+      if (contentProperties.containsKey("airdate")) {
+        String airdate = contentProperties.getString("airdate");
         adContentMetadata.put("airdate", airdate);
       }
 
-      fullEpisodeStatus = content.getBoolean("fullEpisode", false);
-    }
+      fullEpisodeStatus = contentProperties.getBoolean("fullEpisode", false);
 
-    String adLoadType = String.valueOf(options.get("adLoadType"));
-    if (adLoadType.equals("dynamic")) {
-      adContentMetadata.put("adloadtype", "2");
-    } else {
-      adContentMetadata.put("adloadtype", "1");
-    }
+      String adLoadType = String.valueOf(options.get("adLoadType"));
+      if (adLoadType.equals("dynamic")) {
+        adContentMetadata.put("adloadtype", "2");
+      } else {
+        adContentMetadata.put("adloadtype", "1");
+      }
 
-    if (options.containsKey("hasAds") && "true".equals(String.valueOf(options.get("hasAds")))) {
-      adContentMetadata.put("hasAds", "1");
-    } else {
-      adContentMetadata.put("hasAds", "0");
-    }
+      if (options.containsKey("hasAds") && "true".equals(String.valueOf(options.get("hasAds")))) {
+        adContentMetadata.put("hasAds", "1");
+      } else {
+        adContentMetadata.put("hasAds", "0");
+      }
 
-    adContentMetadata.put("isfullepisode", fullEpisodeStatus ? "y" : "sf");
-    adContentMetadata.put("type", "content");
+      adContentMetadata.put("isfullepisode", fullEpisodeStatus ? "y" : "sf");
+      adContentMetadata.put("type", "content");
+    }
 
     return adContentMetadata;
   }

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -33,6 +33,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
   int playheadPosition;
 
   static class Settings {
+    String adAssetIdPropertyName;
     String assetIdPropertyName;
     String clientIdPropertyName;
     String subbrandPropertyName;
@@ -40,6 +41,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
 
     Settings() {
       // Null by default
+      adAssetIdPropertyName = null;
       assetIdPropertyName = null;
       clientIdPropertyName = null;
       subbrandPropertyName = null;
@@ -220,7 +222,8 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
 
     JSONObject adMetadata = mapSpecialKeys(properties, mapper);
 
-    int assetId = properties.getInt("assetId", 0);
+    String adAssetIdPropertyName = (settings.adAssetIdPropertyName != null) ? settings.adAssetIdPropertyName : "assetId";
+    int assetId = properties.getInt(adAssetIdPropertyName, 0);
     adMetadata.put("assetid", String.valueOf(assetId));
 
     String adType = properties.getString("type");

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -233,6 +233,9 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     adMetadata.put("assetid", String.valueOf(assetId));
 
     String adType = properties.getString("type");
+    if (adType != null && !adType.isEmpty()) {
+      adType = adType.replace("-", "");
+    }
     adMetadata.put("type", adType);
 
     String title = String.valueOf(properties.get("title"));

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -222,7 +222,8 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
 
     JSONObject adMetadata = mapSpecialKeys(properties, mapper);
 
-    String adAssetIdPropertyName = (settings.adAssetIdPropertyName != null) ? settings.adAssetIdPropertyName : "assetId";
+    String adAssetIdPropertyName =
+        (settings.adAssetIdPropertyName != null) ? settings.adAssetIdPropertyName : "assetId";
     int assetId = properties.getInt(adAssetIdPropertyName, 0);
     adMetadata.put("assetid", String.valueOf(assetId));
 

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegrationFactory.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegrationFactory.java
@@ -3,13 +3,14 @@ package com.segment.analytics.android.integrations.nielsendcr;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import android.util.Log;
+
 import com.nielsen.app.sdk.AppSdk;
 import com.nielsen.app.sdk.IAppNotifier;
 import com.segment.analytics.Analytics;
 import com.segment.analytics.ValueMap;
 import com.segment.analytics.integrations.Integration;
 import com.segment.analytics.integrations.Logger;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -81,9 +82,9 @@ class NielsenDCRIntegrationFactory implements Integration.Factory {
 
       // Settings
       NielsenDCRIntegration.Settings integrationSettings = new NielsenDCRIntegration.Settings();
-      String assetIdPropertyName = settings.getString("assetIdPropertyName");
-      if (assetIdPropertyName != null && !assetIdPropertyName.isEmpty()) {
-        integrationSettings.assetIdPropertyName = assetIdPropertyName;
+      String contentAssetIdPropertyName = settings.getString("contentAssetIdPropertyName");
+      if (contentAssetIdPropertyName != null && !contentAssetIdPropertyName.isEmpty()) {
+        integrationSettings.contentAssetIdPropertyName = contentAssetIdPropertyName;
       }
       String adAssetIdPropertyName = settings.getString("adAssetIdPropertyName");
       if (adAssetIdPropertyName != null && !adAssetIdPropertyName.isEmpty()) {

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegrationFactory.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegrationFactory.java
@@ -85,6 +85,10 @@ class NielsenDCRIntegrationFactory implements Integration.Factory {
       if (assetIdPropertyName != null && !assetIdPropertyName.isEmpty()) {
         integrationSettings.assetIdPropertyName = assetIdPropertyName;
       }
+      String adAssetIdPropertyName = settings.getString("adAssetIdPropertyName");
+      if (adAssetIdPropertyName != null && !adAssetIdPropertyName.isEmpty()) {
+        integrationSettings.adAssetIdPropertyName = adAssetIdPropertyName;
+      }
       String clientIdPropertyName = settings.getString("clientIdPropertyName");
       if (clientIdPropertyName != null && !clientIdPropertyName.isEmpty()) {
         integrationSettings.clientIdPropertyName = clientIdPropertyName;

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -6,41 +6,40 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.validateMockitoUsage;
-import static org.mockito.Mockito.verify;
-
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatcher;
 import com.nielsen.app.sdk.AppSdk;
 import com.nielsen.app.sdk.IAppNotifier;
 import com.segment.analytics.Analytics;
-
 import com.segment.analytics.Properties;
 import com.segment.analytics.ValueMap;
 import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.ScreenPayload;
 import com.segment.analytics.integrations.TrackPayload;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
-
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.validateMockitoUsage;
+import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -192,7 +191,7 @@ public class NielsenDCRTest {
   @Test
   public void videoContentStarted_settings() throws JSONException {
 
-    settings.assetIdPropertyName = "customAssetId";
+    settings.contentAssetIdPropertyName = "customContentAssetId";
     settings.clientIdPropertyName = "customClientId";
     settings.subbrandPropertyName = "customSubbrand";
     settings.contentLengthPropertyName = "customLength";
@@ -204,7 +203,7 @@ public class NielsenDCRTest {
     integration.track(
             new TrackPayload.Builder().anonymousId("foo").event("Video Content Started").properties(new Properties() //
                     .putValue("assetId", 123214)
-                    .putValue("customAssetId", 1)
+                    .putValue("customContentAssetId", 1)
                     .putValue("title", "Look Who's Purging Now")
                     .putValue("season", 2)
                     .putValue("episode", 9)
@@ -323,12 +322,12 @@ public class NielsenDCRTest {
 
   @Test
   public void videoAdStarted_settings() throws JSONException {
-    settings.adAssetIdPropertyName = "customAssetId";
+    settings.adAssetIdPropertyName = "customAdAssetId";
 
     integration.track(
             new TrackPayload.Builder().anonymousId("foo").event("Video Ad Started").properties(new Properties() //
                     .putValue("assetId", 1234)
-                    .putValue("customAssetId", 4311)
+                    .putValue("customAdAssetId", 4311)
                     .putValue("podId", "adSegmentA")
                     .putValue("type", "mid-roll")
                     .putValue("totalLength", 120)
@@ -420,7 +419,8 @@ public class NielsenDCRTest {
   @Test
   public void videoAdStartedWithTypePreRoll_settings() throws JSONException {
 
-    settings.assetIdPropertyName = "customAssetId";
+    settings.contentAssetIdPropertyName = "customContentAssetId";
+    settings.adAssetIdPropertyName = "customAdAssetId";
     settings.clientIdPropertyName = "customClientId";
     settings.subbrandPropertyName = "customSubbrand";
     settings.contentLengthPropertyName = "customLength";
@@ -429,23 +429,28 @@ public class NielsenDCRTest {
     nielsenOptions.put("segB", "segmentB");
     nielsenOptions.put("hasAds", true);
 
+    JSONObject content = new JSONObject() //
+        .put("podId", "adSegmentA")
+        .put("totalLength", 110)
+        .put("loadType", "linear")
+        .put("position", 20)
+        .put("contentAssetId", 1234)
+        .put("customContentAssetId", 5678)
+        .put("clientId", "badClient")
+        .put("customClientId", "myClient")
+        .put("subbrand", "badBrand")
+        .put("customSubbrand", "myBrand")
+        .put("playbackPosition", 0)
+        .put("title", "Helmet Ad");
+
     integration.track(
             new TrackPayload.Builder().anonymousId("foo").event("Video Ad Started").properties(new Properties() //
-                    .putValue("assetId", 4311)
-                    .putValue("podId", "adSegmentA")
+                    // ad metadata
+                    .putValue("customAdAssetId", 4311)
                     .putValue("type", "pre-roll")
-                    .putValue("totalLength", 110)
-                    .putValue("customLength", 120)
-                    .putValue("loadType", "linear")
-                    .putValue("position", 20)
-                    .putValue("contentAssetId", 1234)
-                    .putValue("customAssetId", 5678)
-                    .putValue("clientId", "badClient")
-                    .putValue("customClientId", "myClient")
-                    .putValue("subbrand", "badBrand")
-                    .putValue("customSubbrand", "myBrand")
-                    .putValue("playbackPosition", 0)
-                    .putValue("title", "Helmet Ad"))
+                    .putValue("type", "pre-roll")
+                    // content metadata
+                    .putValue("content", content))
                     .integration("nielsen-dcr", nielsenOptions).build());
 
     JSONObject contentExpected = new JSONObject();

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -322,6 +322,28 @@ public class NielsenDCRTest {
   }
 
   @Test
+  public void videoAdStarted_settings() throws JSONException {
+    settings.adAssetIdPropertyName = "customAssetId";
+
+    integration.track(
+            new TrackPayload.Builder().anonymousId("foo").event("Video Ad Started").properties(new Properties() //
+                    .putValue("assetId", 1234)
+                    .putValue("customAssetId", 4311)
+                    .putValue("podId", "adSegmentA")
+                    .putValue("type", "mid-roll")
+                    .putValue("totalLength", 120)
+                    .putValue("playbackPosition", 0)
+                    .putValue("title", "Helmet Ad")).build());
+
+    JSONObject expected = new JSONObject();
+    expected.put("assetid", "4311");
+    expected.put("type", "mid-roll");
+    expected.put("title", "Helmet Ad");
+
+    verify(nielsen).loadMetadata(jsonEq(expected));
+  }
+
+  @Test
   public void videoAdStartedWithTypeMidRoll() throws JSONException {
 
     integration.track(

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -434,7 +434,6 @@ public class NielsenDCRTest {
         .put("totalLength", 110)
         .put("loadType", "linear")
         .put("position", 20)
-        .put("contentAssetId", 1234)
         .put("customContentAssetId", 5678)
         .put("clientId", "badClient")
         .put("customClientId", "myClient")
@@ -448,7 +447,7 @@ public class NielsenDCRTest {
                     // ad metadata
                     .putValue("customAdAssetId", 4311)
                     .putValue("type", "pre-roll")
-                    .putValue("type", "pre-roll")
+                    .putValue("title", "Helmet Ad")
                     // content metadata
                     .putValue("content", content))
                     .integration("nielsen-dcr", nielsenOptions).build());

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -402,7 +402,7 @@ public class NielsenDCRTest {
 
     JSONObject adExpected = new JSONObject();
     adExpected.put("assetid", "4311");
-    adExpected.put("type", "pre-roll");
+    adExpected.put("type", "preroll");
     adExpected.put("title", "Helmet Ad");
 
     ArgumentCaptor<JSONObject> captor = ArgumentCaptor.forClass(JSONObject.class);
@@ -467,7 +467,7 @@ public class NielsenDCRTest {
 
     JSONObject adExpected = new JSONObject();
     adExpected.put("assetid", "4311");
-    adExpected.put("type", "pre-roll");
+    adExpected.put("type", "preroll");
     adExpected.put("title", "Helmet Ad");
 
     ArgumentCaptor<JSONObject> captor = ArgumentCaptor.forClass(JSONObject.class);

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -314,7 +314,7 @@ public class NielsenDCRTest {
 
     JSONObject expected = new JSONObject();
     expected.put("assetid", "4311");
-    expected.put("type", "mid-roll");
+    expected.put("type", "midroll");
     expected.put("title", "Helmet Ad");
 
     verify(nielsen).loadMetadata(jsonEq(expected));
@@ -336,7 +336,7 @@ public class NielsenDCRTest {
 
     JSONObject expected = new JSONObject();
     expected.put("assetid", "4311");
-    expected.put("type", "mid-roll");
+    expected.put("type", "midroll");
     expected.put("title", "Helmet Ad");
 
     verify(nielsen).loadMetadata(jsonEq(expected));
@@ -359,7 +359,7 @@ public class NielsenDCRTest {
 
     JSONObject adExpected = new JSONObject();
     adExpected.put("assetid", "4311");
-    adExpected.put("type", "mid-roll");
+    adExpected.put("type", "midroll");
     adExpected.put("title", "Helmet Ad");
 
     verify(nielsen).loadMetadata(jsonEq(adExpected));
@@ -372,19 +372,28 @@ public class NielsenDCRTest {
     nielsenOptions.put("segB", "segmentB");
     nielsenOptions.put("hasAds", true);
 
+    ValueMap contentMetadata = new ValueMap() //
+            .putValue("podId", "adSegmentA")
+            .putValue("totalLength", 120)
+            .putValue("loadType", "linear")
+            .putValue("position", 20)
+            .putValue("contentAssetId", 1234)
+            .putValue("clientId", "myClient")
+            .putValue("subbrand", "myBrand")
+            .putValue("playbackPosition", 0)
+            .putValue("title", "Helmet Ad");
+
+    ValueMap adMetadata = new ValueMap() //
+            .putValue("assetId", 4311)
+            .putValue("type", "pre-roll")
+            .putValue("title", "Helmet Ad");
+
+    Properties trackProperties = new Properties();
+    trackProperties.putAll(adMetadata);
+    trackProperties.put("content", contentMetadata);
+
     integration.track(
-            new TrackPayload.Builder().anonymousId("foo").event("Video Ad Started").properties(new Properties() //
-                    .putValue("assetId", 4311)
-                    .putValue("podId", "adSegmentA")
-                    .putValue("type", "pre-roll")
-                    .putValue("totalLength", 120)
-                    .putValue("loadType", "linear")
-                    .putValue("position", 20)
-                    .putValue("contentAssetId", 1234)
-                    .putValue("clientId", "myClient")
-                    .putValue("subbrand", "myBrand")
-                    .putValue("playbackPosition", 0)
-                    .putValue("title", "Helmet Ad"))
+            new TrackPayload.Builder().anonymousId("foo").event("Video Ad Started").properties(trackProperties) //
                     .integration("nielsen-dcr", nielsenOptions).build());
 
     JSONObject contentExpected = new JSONObject();
@@ -429,27 +438,33 @@ public class NielsenDCRTest {
     nielsenOptions.put("segB", "segmentB");
     nielsenOptions.put("hasAds", true);
 
-    JSONObject content = new JSONObject() //
-        .put("podId", "adSegmentA")
-        .put("totalLength", 110)
-        .put("loadType", "linear")
-        .put("position", 20)
-        .put("customContentAssetId", 5678)
-        .put("clientId", "badClient")
-        .put("customClientId", "myClient")
-        .put("subbrand", "badBrand")
-        .put("customSubbrand", "myBrand")
-        .put("playbackPosition", 0)
-        .put("title", "Helmet Ad");
+    ValueMap contentMetadata = new ValueMap() //
+        .putValue("podId", "adSegmentA")
+        .putValue("customLength", 110)
+        .putValue("loadType", "linear")
+        .putValue("position", 20)
+        .putValue("customContentAssetId", 5678)
+        .putValue("clientId", "badClient")
+        .putValue("customClientId", "myClient")
+        .putValue("subbrand", "badBrand")
+        .putValue("customSubbrand", "myBrand")
+        .putValue("playbackPosition", 0)
+        .putValue("title", "Helmet Ad")
+        .putValue("hasAds", "1")
+        .putValue("segB", "segmentB");
+
+    ValueMap adMetadata = new ValueMap() //
+        .putValue("customAdAssetId", 4311)
+            .putValue("type", "pre-roll")
+          .putValue("title", "Helmet Ad")
+            .putValue("title", "Helmet Ad");
+
+    Properties trackProperties = new Properties();
+    trackProperties.putAll(adMetadata);
+    trackProperties.put("content", contentMetadata);
 
     integration.track(
-            new TrackPayload.Builder().anonymousId("foo").event("Video Ad Started").properties(new Properties() //
-                    // ad metadata
-                    .putValue("customAdAssetId", 4311)
-                    .putValue("type", "pre-roll")
-                    .putValue("title", "Helmet Ad")
-                    // content metadata
-                    .putValue("content", content))
+            new TrackPayload.Builder().anonymousId("foo").event("Video Ad Started").properties(trackProperties) //
                     .integration("nielsen-dcr", nielsenOptions).build());
 
     JSONObject contentExpected = new JSONObject();
@@ -460,7 +475,7 @@ public class NielsenDCRTest {
     contentExpected.put("segB", "segmentB");
     contentExpected.put("clientid", "myClient");
     contentExpected.put("subbrand", "myBrand");
-    contentExpected.put("length", "120");
+    contentExpected.put("length", "110");
     contentExpected.put("adloadtype", "1");
     contentExpected.put("hasAds", "1");
     contentExpected.put("isfullepisode", "sf");


### PR DESCRIPTION
This incorporates 3 main changes/updates:
- Adds support for custom content and ad asset id
- Supports looking in `properties.content` for content metadata upon "Video Ad Started" events
- Improves formatting with `./gradlew fmt` command

The PR also incorporates commits Carlos already made. This can be seen in the commit history below.

Once this PR is approved, I'll merge to master and release. We will not need to await Fox approval before releasing the new SDK version.