### PR TITLE
Expose underlying Nielsen SDK instance.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=1.2.0-SNAPSHOT
+VERSION=1.2.1-SNAPSHOT
 
 POM_ARTIFACT_ID=nielsendcr
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -555,4 +555,9 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     appSdk.loadMetadata(metadata);
     logger.verbose("appSdk.loadMetadata(%s)", metadata);
   }
+
+  @Override
+  public AppSdk getUnderlyingInstance() {
+    return appSdk;
+  }
 }


### PR DESCRIPTION
* This is a very simple PR that supports exposing the underlying Nielsen SDK instance to customers.
* The PR does not introduce any breaking changes and does not require a new setting.
* Because the change is isolated, it shouldn't require a CC ticket.

Customers will now be able to access the underlying Nielsen SDK instance following this paradigm from our docs: https://segment.com/docs/sources/mobile/android/#how-can-i-use-an-destination-specific-feature-e-g-mixpanel-s-push-notifications-