### PR TITLE
Updates to property mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+1.2.3 / 2019-09-09
+==================
+
+  * Update property mappings for `assetid`, `isFullEpisode` and `length`
+  * Add fallback to look for `loadType` in event properties if `adLoadType` not in options
+
 1.2.2 / 2019-08-30
 ==================
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=1.2.2-SNAPSHOT
+VERSION=1.2.3-SNAPSHOT
 
 POM_ARTIFACT_ID=nielsendcr
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -214,7 +214,15 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
       contentMetadata.put("airdate", airdate);
     }
 
-    String adLoadType = String.valueOf(options.get("adLoadType"));
+    String adLoadType = "";
+    if (options.containsKey("adLoadType")) {
+      adLoadType = String.valueOf(options.get("adLoadType"));
+    }
+    if (adLoadType.isEmpty() || adLoadType.equals("null")) {
+      if (properties.containsKey("loadType")) {
+        adLoadType = properties.getString("loadType");
+      }
+    }
     if (adLoadType.equals("dynamic")) {
       contentMetadata.put("adloadtype", "2");
     } else {
@@ -349,7 +357,15 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
         adContentMetadata.put("airdate", airdate);
       }
 
-      String adLoadType = String.valueOf(options.get("adLoadType"));
+      String adLoadType = "";
+      if (options.containsKey("adLoadType")) {
+        adLoadType = String.valueOf(options.get("adLoadType"));
+      }
+      if (adLoadType.isEmpty() || adLoadType.equals("null")) {
+        if (contentProperties.containsKey("loadType")) {
+          adLoadType = String.valueOf(contentProperties.get("loadType"));
+        }
+      }
       if (adLoadType.equals("dynamic")) {
         adContentMetadata.put("adloadtype", "2");
       } else {

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -170,8 +170,8 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
         (settings.contentAssetIdPropertyName != null)
             ? settings.contentAssetIdPropertyName
             : "assetId";
-    int contentAssetId = properties.getInt(contentAssetIdPropertyName, 0);
-    contentMetadata.put("assetid", String.valueOf(contentAssetId));
+    String contentAssetId = properties.getString(contentAssetIdPropertyName);
+    contentMetadata.put("assetid", contentAssetId);
 
     String clientIdPropertyName =
         (settings.clientIdPropertyName != null) ? settings.clientIdPropertyName : "clientId";
@@ -192,8 +192,8 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
             ? settings.contentLengthPropertyName
             : "totalLength";
     if (properties.containsKey(lengthPropertyName)) {
-      int length = properties.getInt(lengthPropertyName, 0);
-      contentMetadata.put("length", String.valueOf(length));
+      String length = properties.getString(lengthPropertyName);
+      contentMetadata.put("length", length);
     }
 
     if (properties.containsKey("title")) {
@@ -228,8 +228,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     }
 
     boolean fullEpisodeStatus = properties.getBoolean("fullEpisode", false);
-    contentMetadata.put("isfullepisode", fullEpisodeStatus ? "y" : "sf");
-
+    contentMetadata.put("isfullepisode", fullEpisodeStatus ? "y" : "n");
     contentMetadata.put("type", "content");
 
     return contentMetadata;
@@ -242,8 +241,8 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
 
     String adAssetIdPropertyName =
         (settings.adAssetIdPropertyName != null) ? settings.adAssetIdPropertyName : "assetId";
-    int assetId = properties.getInt(adAssetIdPropertyName, 0);
-    adMetadata.put("assetid", String.valueOf(assetId));
+    String assetId = properties.getString(adAssetIdPropertyName);
+    adMetadata.put("assetid", assetId);
 
     String adType = properties.getString("type");
     if (adType != null && !adType.isEmpty()) {
@@ -302,14 +301,12 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
         adContentMetadata.put("segC", segC);
       }
 
-      boolean fullEpisodeStatus = false;
-
       String contentAssetIdPropertyName =
           (settings.contentAssetIdPropertyName != null)
               ? settings.contentAssetIdPropertyName
               : "contentAssetId";
-      int contentAssetId = contentProperties.getInt(contentAssetIdPropertyName, 0);
-      adContentMetadata.put("assetid", String.valueOf(contentAssetId));
+      String contentAssetId = contentProperties.getString(contentAssetIdPropertyName);
+      adContentMetadata.put("assetid", contentAssetId);
 
       String clientIdPropertyName =
           (settings.clientIdPropertyName != null) ? settings.clientIdPropertyName : "clientId";
@@ -330,8 +327,8 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
               ? settings.contentLengthPropertyName
               : "totalLength";
       if (contentProperties.containsKey(lengthPropertyName)) {
-        int length = contentProperties.getInt(lengthPropertyName, 0);
-        adContentMetadata.put("length", String.valueOf(length));
+        String length = contentProperties.getString(lengthPropertyName);
+        adContentMetadata.put("length", length);
       }
 
       if (contentProperties.containsKey("title")) {
@@ -352,8 +349,6 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
         adContentMetadata.put("airdate", airdate);
       }
 
-      fullEpisodeStatus = contentProperties.getBoolean("fullEpisode", false);
-
       String adLoadType = String.valueOf(options.get("adLoadType"));
       if (adLoadType.equals("dynamic")) {
         adContentMetadata.put("adloadtype", "2");
@@ -367,7 +362,8 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
         adContentMetadata.put("hasAds", "0");
       }
 
-      adContentMetadata.put("isfullepisode", fullEpisodeStatus ? "y" : "sf");
+      boolean fullEpisodeStatus = contentProperties.getBoolean("fullEpisode", false);
+      adContentMetadata.put("isfullepisode", fullEpisodeStatus ? "y" : "n");
       adContentMetadata.put("type", "content");
     }
 

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -168,6 +168,7 @@ public class NielsenDCRTest {
                     .putValue("podId", "segment A")
                     .putValue("playbackPosition", 70)
                     .putValue("totalLength", 1200)
+                    .putValue("loadType", "dynamic")
                     .putValue("airdate", "2019-08-27T17:00:00Z"))
                     .integration("nielsen-dcr", nielsenOptions)
                     .build());
@@ -180,7 +181,7 @@ public class NielsenDCRTest {
     expected.put("pipmode", "false");
     expected.put("isfullepisode", "y");
     expected.put("type", "content");
-    expected.put("adloadtype", "1");
+    expected.put("adloadtype", "2");
     expected.put("hasAds", "0");
     expected.put("crossId2", "id");
     expected.put("clientid", "myClient");

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -496,7 +496,7 @@ public class NielsenDCRTest {
     contentExpected.put("length", "120");
     contentExpected.put("adloadtype", "1");
     contentExpected.put("hasAds", "1");
-    contentExpected.put("isfullepisode", "sf");
+    contentExpected.put("isfullepisode", "n");
 
     JSONObject adExpected = new JSONObject();
     adExpected.put("assetid", "4311");
@@ -567,7 +567,7 @@ public class NielsenDCRTest {
     contentExpected.put("length", "110");
     contentExpected.put("adloadtype", "1");
     contentExpected.put("hasAds", "1");
-    contentExpected.put("isfullepisode", "sf");
+    contentExpected.put("isfullepisode", "n");
 
     JSONObject adExpected = new JSONObject();
     adExpected.put("assetid", "4311");


### PR DESCRIPTION
This PR fixes some mapping issues identified internally and raised by customers:

- Uses `getString()` method to retrieve `assetid` rather than `getInt()`, as Fox uses alphanumeric strings for their assetids [ensures parity with iOS]
- Passes `isFullEpisode` as either "y" or "n" rather than "y" or "sf" [ensures parity with iOS]
- Passes `length` as a string rather than an int [ensures parity with iOS]
- Adds fallback to look for `loadType` in properties rather than for `adLoadType` in integrations options only (ensures parity with DTVR)