### PR TITLE
[DEST-1006] Hard code "dcr" as value of sfcode setting.

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegrationFactory.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegrationFactory.java
@@ -29,6 +29,8 @@ class NielsenDCRIntegrationFactory implements Integration.Factory {
   }
 
   private static final String NIELSEN_DCR_KEY = "Nielsen DCR";
+  // "sfcode" used to be a UI setting, but should now be hard-coded to "dcr" per Nielsen support
+  private static final String SF_CODE = "dcr";
 
   private final AppSDKFactory appSDKFactory;
 
@@ -59,9 +61,6 @@ class NielsenDCRIntegrationFactory implements Integration.Factory {
       return null;
     }
 
-    boolean sfcodeValue = settings.getBoolean("sfCode", false);
-    String sfCode = sfcodeValue ? "dcr" : "dcr-cert";
-
     String appId = settings.getString("appId");
 
     try {
@@ -71,7 +70,7 @@ class NielsenDCRIntegrationFactory implements Integration.Factory {
               .put("appid", appId)
               .put("appname", appname)
               .put("appversion", appversion)
-              .put("sfcode", sfCode);
+              .put("sfcode", SF_CODE);
 
       if (settings.getBoolean("nolDevDebug", false)) {
         appSdkConfig.put("nol_devDebug", "DEBUG");

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -88,7 +88,6 @@ public class NielsenDCRTest {
   public void appSdkConfig() throws JSONException {
     ValueMap settings = new ValueMap();
     settings.put("appId", "12345");
-    settings.put("sfCode", true);
     settings.put("nolDevDebug", true);
 
     factory.create(settings, analytics);


### PR DESCRIPTION
This is the CI build we care about: https://ci.segment.com/gh/segment-integrations/analytics-android-integration-nielsen-dcr/117

https://segment.atlassian.net/browse/DEST-1006

Per Nielsen, the value of "sfcode" should always be "dcr" from now on, so we are going to hard code that value and hide the UI setting.