### PR TITLE
[DEST-1240] Accept camelCase and snake_case specced video properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=1.2.4-SNAPSHOT
+VERSION=1.3.0-SNAPSHOT
 
 POM_ARTIFACT_ID=nielsendcr
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -43,6 +43,81 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
   private static final Pattern LONG_DATE =
       Pattern.compile("^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})Z$");
 
+  private static final Map<String, String> CONTENT_FORMATTER = getContentFormatter();
+
+  private static Map<String, String> getContentFormatter() {
+    Map<String, String> contentFormatter = new LinkedHashMap<>();
+
+    contentFormatter.put("session_id", "sessionId");
+    contentFormatter.put("asset_id", "assetId");
+    contentFormatter.put("pod_id", "podId");
+    contentFormatter.put("total_length", "totalLength");
+    contentFormatter.put("full_episode", "fullEpisode");
+    contentFormatter.put("content_asset_id", "contentAssetId");
+    contentFormatter.put("ad_asset_id", "adAssetId");
+    contentFormatter.put("load_type", "loadType");
+
+    return contentFormatter;
+  }
+
+  private static final Map<String, String> AD_FORMATTER = getAdFormatter();
+
+  private static Map<String, String> getAdFormatter() {
+    Map<String, String> adFormatter = new LinkedHashMap<>();
+
+    adFormatter.put("session_id", "sessionId");
+    adFormatter.put("asset_id", "assetId");
+    adFormatter.put("pod_id", "podId");
+    adFormatter.put("pod_position", "podPosition");
+    adFormatter.put("pod_length", "podLength");
+    adFormatter.put("total_length", "totalLength");
+    adFormatter.put("load_type", "loadType");
+
+    return adFormatter;
+  }
+
+  private static final Map<String, String> CONTENT_MAP = getContentMap();
+
+  private static Map<String, String> getContentMap() {
+    Map<String, String> contentMap = new LinkedHashMap<>();
+
+    contentMap.put("assetId", "assetid");
+    contentMap.put("contentAssetId", "assetid");
+    contentMap.put("title", "title");
+    contentMap.put("program", "program");
+
+    return contentMap;
+  }
+
+  private static final Map<String, String> AD_MAP = getAdMap();
+
+  private static Map<String, String> getAdMap() {
+    Map<String, String> adMap = new LinkedHashMap<>();
+
+    adMap.put("assetId", "assetid");
+    adMap.put("type", "type");
+    adMap.put("title", "title");
+
+    return adMap;
+  }
+
+  private ValueMap toSegmentSpec(
+      @NonNull ValueMap properties, @NonNull Map<String, String> formatter) {
+    ValueMap mappedProperties = new ValueMap();
+    mappedProperties.putAll(properties);
+
+    for (Map.Entry<String, String> entry : formatter.entrySet()) {
+      String key = entry.getKey();
+      String value = entry.getValue();
+      if (mappedProperties.get(key) != null) {
+        mappedProperties.put(value, mappedProperties.get(key));
+        mappedProperties.remove(key);
+      }
+    }
+
+    return mappedProperties;
+  }
+
   static class Settings {
     String adAssetIdPropertyName;
     String contentAssetIdPropertyName;
@@ -68,7 +143,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     this.logger = logger;
   }
 
-  private void startPlayheadTimer(final Properties properties, final AppSdk nielsen) {
+  private void startPlayheadTimer(final ValueMap properties, final AppSdk nielsen) {
     if (playheadTimer != null) {
       return;
     }
@@ -113,7 +188,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
   }
 
   private JSONObject mapSpecialKeys(
-      @NonNull Properties properties, @NonNull Map<String, String> mapper) throws JSONException {
+      @NonNull ValueMap properties, @NonNull Map<String, String> mapper) throws JSONException {
     JSONObject metadata = new JSONObject();
 
     // Map special keys and preserve only the special keys.
@@ -130,13 +205,11 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
   }
 
   private @NonNull JSONObject buildContentMetadata(
-      @NonNull Properties properties,
-      @NonNull Map<String, ?> options,
-      @NonNull Map<String, String> mapper)
-      throws JSONException {
+      @NonNull ValueMap properties, @NonNull Map<String, ?> options) throws JSONException {
 
-    JSONObject contentMetadata = mapSpecialKeys(properties, mapper);
+    JSONObject contentMetadata = mapSpecialKeys(properties, CONTENT_MAP);
 
+    // map payload options to Nielsen content metadata fields
     if (options.containsKey("pipmode")) {
       String pipmode = String.valueOf(options.get("pipmode"));
       contentMetadata.put("pipmode", pipmode);
@@ -164,11 +237,26 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
       contentMetadata.put("segC", segC);
     }
 
+    if (options.containsKey("hasAds") && "true".equals(String.valueOf(options.get("hasAds")))) {
+      contentMetadata.put("hasAds", "1");
+    } else {
+      contentMetadata.put("hasAds", "0");
+    }
+
+    // map settings to Nielsen content metadata fields
     String contentAssetIdPropertyName =
         (settings.contentAssetIdPropertyName != null)
             ? settings.contentAssetIdPropertyName
             : "assetId";
-    String contentAssetId = properties.getString(contentAssetIdPropertyName);
+
+    String contentAssetId = "";
+    if (settings.contentAssetIdPropertyName != null) {
+      contentAssetId = properties.getString(settings.contentAssetIdPropertyName);
+    } else if (properties.getString("assetId") != null) {
+      contentAssetId = properties.getString("assetId");
+    } else {
+      contentAssetId = properties.getString("contentAssetId");
+    }
     contentMetadata.put("assetid", contentAssetId);
 
     String clientIdPropertyName =
@@ -194,16 +282,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
       contentMetadata.put("length", length);
     }
 
-    if (properties.containsKey("title")) {
-      String title = properties.getString("title");
-      contentMetadata.put("title", title);
-    }
-
-    if (properties.containsKey("program")) {
-      String program = properties.getString("program");
-      contentMetadata.put("program", program);
-    }
-
+    // map properties with non-String values to Nielsen content metadata fields
     if (properties.containsKey("airdate")) {
       String airdate = properties.getString("airdate");
       if (airdate != null && !airdate.isEmpty()) {
@@ -219,20 +298,12 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     if (adLoadType.isEmpty() || adLoadType.equals("null")) {
       if (properties.containsKey("loadType")) {
         adLoadType = properties.getString("loadType");
-      } else if (properties.containsKey("load_type")) {
-        adLoadType = properties.getString("load_type");
       }
     }
     if (adLoadType.equals("dynamic")) {
       contentMetadata.put("adloadtype", "2");
     } else {
       contentMetadata.put("adloadtype", "1");
-    }
-
-    if (options.containsKey("hasAds") && "true".equals(String.valueOf(options.get("hasAds")))) {
-      contentMetadata.put("hasAds", "1");
-    } else {
-      contentMetadata.put("hasAds", "0");
     }
 
     boolean fullEpisodeStatus = properties.getBoolean("fullEpisode", false);
@@ -242,10 +313,9 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     return contentMetadata;
   }
 
-  private @NonNull JSONObject buildAdMetadata(
-      @NonNull Properties properties, @NonNull Map<String, String> mapper) throws JSONException {
+  private @NonNull JSONObject buildAdMetadata(@NonNull ValueMap properties) throws JSONException {
 
-    JSONObject adMetadata = mapSpecialKeys(properties, mapper);
+    JSONObject adMetadata = mapSpecialKeys(properties, AD_MAP);
 
     String adAssetIdPropertyName =
         (settings.adAssetIdPropertyName != null) ? settings.adAssetIdPropertyName : "assetId";
@@ -264,130 +334,6 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     adMetadata.put("title", title);
 
     return adMetadata;
-  }
-
-  private @NonNull JSONObject buildAdContentMetadata(
-      @NonNull Properties properties,
-      @NonNull Map<String, ?> options,
-      @NonNull Map<String, String> mapper)
-      throws JSONException {
-
-    Properties contentProperties = new Properties();
-    JSONObject adContentMetadata = new JSONObject(); // initialize to prevent null pointer exception
-
-    if (properties.containsKey("content") && !properties.getValueMap("content").isEmpty()) {
-      ValueMap content = properties.getValueMap("content");
-      contentProperties.putAll(content);
-    }
-
-    if (!contentProperties.isEmpty()) {
-
-      adContentMetadata = mapSpecialKeys(contentProperties, mapper);
-
-      if (options.containsKey("pipmode")) {
-        String pipmode = String.valueOf(options.get("pipmode"));
-        adContentMetadata.put("pipmode", pipmode);
-      } else {
-        adContentMetadata.put("pipmode", "false");
-      }
-
-      if (options.containsKey("crossId1")) {
-        String crossId1 = String.valueOf(options.get("crossId1"));
-        adContentMetadata.put("crossId1", crossId1);
-      }
-
-      if (options.containsKey("crossId2")) {
-        String crossId2 = String.valueOf(options.get("crossId2"));
-        adContentMetadata.put("crossId2", crossId2);
-      }
-
-      if (options.containsKey("segB")) {
-        String segB = String.valueOf(options.get("segB"));
-        adContentMetadata.put("segB", segB);
-      }
-
-      if (options.containsKey("segC")) {
-        String segC = String.valueOf(options.get("segC"));
-        adContentMetadata.put("segC", segC);
-      }
-
-      String contentAssetIdPropertyName =
-          (settings.contentAssetIdPropertyName != null)
-              ? settings.contentAssetIdPropertyName
-              : "contentAssetId";
-      String contentAssetId = contentProperties.getString(contentAssetIdPropertyName);
-      adContentMetadata.put("assetid", contentAssetId);
-
-      String clientIdPropertyName =
-          (settings.clientIdPropertyName != null) ? settings.clientIdPropertyName : "clientId";
-      String clientId = contentProperties.getString(clientIdPropertyName);
-      if (clientId != null && !clientId.isEmpty()) {
-        adContentMetadata.put("clientid", clientId);
-      }
-
-      String subbrandPropertyName =
-          (settings.subbrandPropertyName != null) ? settings.subbrandPropertyName : "subbrand";
-      String subbrand = contentProperties.getString(subbrandPropertyName);
-      if (subbrand != null && !subbrand.isEmpty()) {
-        adContentMetadata.put("subbrand", subbrand);
-      }
-
-      String lengthPropertyName =
-          (settings.contentLengthPropertyName != null)
-              ? settings.contentLengthPropertyName
-              : "totalLength";
-      if (contentProperties.containsKey(lengthPropertyName)) {
-        String length = contentProperties.getString(lengthPropertyName);
-        adContentMetadata.put("length", length);
-      }
-
-      if (contentProperties.containsKey("title")) {
-        String title = contentProperties.getString("title");
-        adContentMetadata.put("title", title);
-      }
-
-      if (contentProperties.containsKey("program")) {
-        String program = contentProperties.getString("program");
-        adContentMetadata.put("program", program);
-      }
-
-      if (contentProperties.containsKey("airdate")) {
-        String airdate = contentProperties.getString("airdate");
-        if (airdate != null && !airdate.isEmpty()) {
-          airdate = formatAirdate(contentProperties.getString("airdate"));
-        }
-        adContentMetadata.put("airdate", airdate);
-      }
-
-      String adLoadType = "";
-      if (options.containsKey("adLoadType")) {
-        adLoadType = String.valueOf(options.get("adLoadType"));
-      }
-      if (adLoadType.isEmpty() || adLoadType.equals("null")) {
-        if (contentProperties.containsKey("loadType")) {
-          adLoadType = String.valueOf(contentProperties.get("loadType"));
-        } else if (contentProperties.containsKey("load_type")) {
-          adLoadType = String.valueOf(contentProperties.get("load_type"));
-        }
-      }
-      if (adLoadType.equals("dynamic")) {
-        adContentMetadata.put("adloadtype", "2");
-      } else {
-        adContentMetadata.put("adloadtype", "1");
-      }
-
-      if (options.containsKey("hasAds") && "true".equals(String.valueOf(options.get("hasAds")))) {
-        adContentMetadata.put("hasAds", "1");
-      } else {
-        adContentMetadata.put("hasAds", "0");
-      }
-
-      boolean fullEpisodeStatus = contentProperties.getBoolean("fullEpisode", false);
-      adContentMetadata.put("isfullepisode", fullEpisodeStatus ? "y" : "n");
-      adContentMetadata.put("type", "content");
-    }
-
-    return adContentMetadata;
   }
 
   public String formatAirdate(String airdate) {
@@ -442,7 +388,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
   }
 
   private void trackVideoPlayback(
-      TrackPayload track, Properties properties, Map<String, Object> nielsenOptions)
+      TrackPayload track, ValueMap properties, Map<String, Object> nielsenOptions)
       throws JSONException {
     String event = track.event();
 
@@ -490,24 +436,18 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
       throws JSONException {
     String event = track.event();
 
-    Map<String, String> contentMapper = new LinkedHashMap<>();
-    contentMapper.put("assetId", "assetid");
-    contentMapper.put("title", "title");
-    contentMapper.put("program", "program");
-    contentMapper.put("totalLength", "length");
-    contentMapper.put("airdate", "airdate");
-
-    JSONObject contentMetadata = buildContentMetadata(properties, nielsenOptions, contentMapper);
+    ValueMap contentProperties = toSegmentSpec(properties, CONTENT_FORMATTER);
+    JSONObject contentMetadata = buildContentMetadata(contentProperties, nielsenOptions);
 
     switch (event) {
       case "Video Content Started":
-        startPlayheadTimer(properties, appSdk);
+        startPlayheadTimer(contentProperties, appSdk);
         appSdk.loadMetadata(contentMetadata);
         logger.verbose("appSdk.loadMetadata(%s)", contentMetadata);
         break;
 
       case "Video Content Playing":
-        startPlayheadTimer(properties, appSdk);
+        startPlayheadTimer(contentProperties, appSdk);
         break;
 
       case "Video Content Completed":
@@ -517,33 +457,34 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     }
   }
 
-  public void trackVideoAd(
+  private void trackVideoAd(
       TrackPayload track, Properties properties, Map<String, Object> nielsenOptions)
       throws JSONException {
     String event = track.event();
 
-    Map<String, String> adMapper = new LinkedHashMap<>();
-    adMapper.put("assetId", "assetid");
-    adMapper.put("type", "type");
-    adMapper.put("title", "title");
+    ValueMap adProperties = toSegmentSpec(properties, AD_FORMATTER);
 
     switch (event) {
       case "Video Ad Started":
         // In case of ad `type` preroll, call `loadMetadata` with metadata values for content,
         // followed by `loadMetadata` with ad (preroll) metadata
         if ("pre-roll".equals(properties.getString("type"))) {
-          JSONObject adContentAsset = buildAdContentMetadata(properties, nielsenOptions, adMapper);
-          appSdk.loadMetadata(adContentAsset);
-          logger.verbose("appSdk.loadMetadata(%s)", adContentAsset);
+          if (properties.containsKey("content") && !properties.getValueMap("content").isEmpty()) {
+            ValueMap contentMap = properties.getValueMap("content");
+            ValueMap contentProperties = toSegmentSpec(contentMap, CONTENT_FORMATTER);
+            JSONObject adContentAsset = buildContentMetadata(contentProperties, nielsenOptions);
+            appSdk.loadMetadata(adContentAsset);
+            logger.verbose("appSdk.loadMetadata(%s)", adContentAsset);
+          }
         }
-        JSONObject adAsset = buildAdMetadata(properties, adMapper);
+        JSONObject adAsset = buildAdMetadata(adProperties);
         appSdk.loadMetadata(adAsset);
         logger.verbose("appSdk.loadMetadata(%s)", adAsset);
-        startPlayheadTimer(properties, appSdk);
+        startPlayheadTimer(adProperties, appSdk);
         break;
 
       case "Video Ad Playing":
-        startPlayheadTimer(properties, appSdk);
+        startPlayheadTimer(adProperties, appSdk);
         break;
 
       case "Video Ad Completed":

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -43,7 +43,8 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
   private static final Pattern LONG_DATE =
       Pattern.compile("^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})Z$");
 
-  private static final Map<String, String> CONTENT_FORMATTER = getContentFormatter();
+  private static final Map<String, String> CONTENT_FORMATTER =
+      Collections.unmodifiableMap(getContentFormatter());
 
   private static Map<String, String> getContentFormatter() {
     Map<String, String> contentFormatter = new LinkedHashMap<>();
@@ -60,7 +61,8 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     return contentFormatter;
   }
 
-  private static final Map<String, String> AD_FORMATTER = getAdFormatter();
+  private static final Map<String, String> AD_FORMATTER =
+      Collections.unmodifiableMap(getAdFormatter());
 
   private static Map<String, String> getAdFormatter() {
     Map<String, String> adFormatter = new LinkedHashMap<>();
@@ -76,7 +78,8 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     return adFormatter;
   }
 
-  private static final Map<String, String> CONTENT_MAP = getContentMap();
+  private static final Map<String, String> CONTENT_MAP =
+      Collections.unmodifiableMap(getContentMap());
 
   private static Map<String, String> getContentMap() {
     Map<String, String> contentMap = new LinkedHashMap<>();
@@ -89,7 +92,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     return contentMap;
   }
 
-  private static final Map<String, String> AD_MAP = getAdMap();
+  private static final Map<String, String> AD_MAP = Collections.unmodifiableMap(getAdMap());
 
   private static Map<String, String> getAdMap() {
     Map<String, String> adMap = new LinkedHashMap<>();
@@ -101,6 +104,17 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     return adMap;
   }
 
+  /**
+   * For Segment-specced video event properties, this helper method maps keys in snake_case to
+   * camelCase. The actual content and ad property mapping logic in this SDK only handles camelCase
+   * property keys.
+   *
+   * <p>Segment's video spec: https://segment.com/docs/spec/video/
+   *
+   * @param properties Segment event payload properties
+   * @param formatter Either CONTENT_FORMATTER or AD_FORMATTER
+   * @return
+   */
   private ValueMap toSegmentSpec(
       @NonNull ValueMap properties, @NonNull Map<String, String> formatter) {
     ValueMap mappedProperties = new ValueMap();
@@ -237,7 +251,9 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
       contentMetadata.put("segC", segC);
     }
 
-    if (options.containsKey("hasAds") && "true".equals(String.valueOf(options.get("hasAds")))) {
+    if (options.containsKey("hasAds")
+        && options.get("hasAds") != null
+        && "true".equals(String.valueOf(options.get("hasAds")))) {
       contentMetadata.put("hasAds", "1");
     } else {
       contentMetadata.put("hasAds", "0");

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -76,9 +76,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     playheadPosition = properties.getInt("position", 0);
     monitorHeadPos =
         new TimerTask() {
-          boolean isLiveStream =
-              "content".equals(properties.getString("type"))
-                  && properties.getBoolean("livestream", false);
+          boolean isLiveStream = properties.getBoolean("livestream", false);
 
           @Override
           public void run() {
@@ -257,6 +255,8 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     String adType = properties.getString("type");
     if (adType != null && !adType.isEmpty()) {
       adType = adType.replace("-", "");
+    } else {
+      adType = "ad";
     }
     adMetadata.put("type", adType);
 
@@ -463,18 +463,19 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     switch (event) {
       case "Video Playback Started":
       case "Video Playback Resumed":
+      case "Video Playback Seek Completed":
+      case "Video Playback Buffer Completed":
         startPlayheadTimer(properties, appSdk);
         appSdk.play(channelInfo);
         logger.verbose("appSdk.play(%s)", channelInfo);
         break;
       case "Video Playback Paused":
       case "Video Playback Interrupted":
+      case "Video Playback Seek Started":
+      case "Video Playback Buffer Started":
         stopPlayheadTimer();
         appSdk.stop();
         logger.verbose("appSdk.stop()");
-        break;
-      case "Video Playback Seek Completed":
-        startPlayheadTimer(properties, appSdk);
         break;
       case "Video Playback Completed":
         stopPlayheadTimer();
@@ -510,7 +511,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
         break;
 
       case "Video Content Completed":
-        appSdk.end();
+        appSdk.stop();
         stopPlayheadTimer();
         break;
     }
@@ -567,7 +568,10 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
       case "Video Playback Started":
       case "Video Playback Paused":
       case "Video Playback Interrupted":
+      case "Video Playback Seek Started":
       case "Video Playback Seek Completed":
+      case "Video Playback Buffer Started":
+      case "Video Playback Buffer Completed":
       case "Video Playback Resumed":
         try {
           trackVideoPlayback(track, properties, nielsenOptions);

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -104,34 +104,6 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     return adMap;
   }
 
-  /**
-   * For Segment-specced video event properties, this helper method maps keys in snake_case to
-   * camelCase. The actual content and ad property mapping logic in this SDK only handles camelCase
-   * property keys, even though Segment's video spec requires all keys in snake_case format.
-   *
-   * <p>Segment's video spec: https://segment.com/docs/spec/video/
-   *
-   * @param properties Segment event payload properties
-   * @param formatter Either CONTENT_FORMATTER or AD_FORMATTER
-   * @return properties Segment event payload properties with keys formatter per Segment video spec
-   */
-  private ValueMap toCamelCase(
-      @NonNull ValueMap properties, @NonNull Map<String, String> formatter) {
-    ValueMap mappedProperties = new ValueMap();
-    mappedProperties.putAll(properties);
-
-    for (Map.Entry<String, String> entry : formatter.entrySet()) {
-      String key = entry.getKey();
-      String value = entry.getValue();
-      if (mappedProperties.get(key) != null) {
-        mappedProperties.put(value, mappedProperties.get(key));
-        mappedProperties.remove(key);
-      }
-    }
-
-    return mappedProperties;
-  }
-
   static class Settings {
     String adAssetIdPropertyName;
     String contentAssetIdPropertyName;
@@ -202,6 +174,34 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     long millis = calendar.getTimeInMillis();
     long utcTime = TimeUnit.MILLISECONDS.toSeconds(millis) + playheadPosition;
     return utcTime;
+  }
+
+  /**
+   * For Segment-specced video event properties, this helper method maps keys in snake_case to
+   * camelCase. The actual content and ad property mapping logic in this SDK only handles camelCase
+   * property keys, even though Segment's video spec requires all keys in snake_case format.
+   *
+   * <p>Segment's video spec: https://segment.com/docs/spec/video/
+   *
+   * @param properties Segment event payload properties
+   * @param formatter Either CONTENT_FORMATTER or AD_FORMATTER
+   * @return properties Segment event payload properties with keys formatter per Segment video spec
+   */
+  private ValueMap toCamelCase(
+      @NonNull ValueMap properties, @NonNull Map<String, String> formatter) {
+    ValueMap mappedProperties = new ValueMap();
+    mappedProperties.putAll(properties);
+
+    for (Map.Entry<String, String> entry : formatter.entrySet()) {
+      String key = entry.getKey();
+      String value = entry.getValue();
+      if (mappedProperties.get(key) != null) {
+        mappedProperties.put(value, mappedProperties.get(key));
+        mappedProperties.remove(key);
+      }
+    }
+
+    return mappedProperties;
   }
 
   private JSONObject mapSpecialKeys(
@@ -430,13 +430,13 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
         logger.verbose("appSdk.play(%s)", channelInfo);
         break;
       case "Video Playback Paused":
-      case "Video Playback Interrupted":
       case "Video Playback Seek Started":
       case "Video Playback Buffer Started":
         stopPlayheadTimer();
         appSdk.stop();
         logger.verbose("appSdk.stop()");
         break;
+      case "Video Playback Interrupted":
       case "Video Playback Completed":
         stopPlayheadTimer();
         appSdk.end();

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegrationFactory.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegrationFactory.java
@@ -29,6 +29,8 @@ class NielsenDCRIntegrationFactory implements Integration.Factory {
   }
 
   private static final String NIELSEN_DCR_KEY = "Nielsen DCR";
+  // "sfcode" used to be a UI setting, but should now be hard-coded to "dcr" per Nielsen support
+  private static final String SF_CODE = "dcr";
 
   private final AppSDKFactory appSDKFactory;
 
@@ -59,9 +61,6 @@ class NielsenDCRIntegrationFactory implements Integration.Factory {
       return null;
     }
 
-    boolean sfcodeValue = settings.getBoolean("sfCode", false);
-    String sfCode = sfcodeValue ? "dcr" : "dcr-cert";
-
     String appId = settings.getString("appId");
 
     try {
@@ -71,7 +70,7 @@ class NielsenDCRIntegrationFactory implements Integration.Factory {
               .put("appid", appId)
               .put("appname", appname)
               .put("appversion", appversion)
-              .put("sfcode", sfCode);
+              .put("sfcode", SF_CODE);
 
       if (settings.getBoolean("nolDevDebug", false)) {
         appSdkConfig.put("nol_devDebug", "DEBUG");

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -145,6 +145,29 @@ public class NielsenDCRTest {
   }
 
   @Test
+  public void videoPlaybackInterrupted() {
+
+    Map<String, Object> nielsenOptions = new LinkedHashMap<>();
+    nielsenOptions.put("channelName", "exampleChannelName");
+
+    integration.track(new TrackPayload.Builder().anonymousId("foo") //
+            .event("Video Playback Interrupted")
+            .properties(new Properties() //
+                    .putValue("assetId", 1234)
+                    .putValue("adType", "mid-roll")
+                    .putValue("totalLength", 100)
+                    .putValue("videoPlayer", "vimeo")
+                    .putValue("position", 10)
+                    .putValue("fullScreen", true)
+                    .putValue("bitrate", 50)
+                    .putValue("sound", 80))
+            .integration("nielsen-dcr", nielsenOptions)
+            .build());
+
+    verify(nielsen).end();
+  }
+
+  @Test
   public void videoContentStarted() throws JSONException {
 
     Map<String, Object> nielsenOptions = new LinkedHashMap<>();

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -88,7 +88,6 @@ public class NielsenDCRTest {
   public void appSdkConfig() throws JSONException {
     ValueMap settings = new ValueMap();
     settings.put("appId", "12345");
-    settings.put("sfCode", true);
     settings.put("nolDevDebug", true);
 
     factory.create(settings, analytics);

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -514,14 +514,14 @@ public class NielsenDCRTest {
             .putValue("totalLength", 120)
             .putValue("load_type", "dynamic")
             .putValue("position", 20)
-            .putValue("contentAssetId", 1234)
+            .putValue("contentAssetId", "1234")
             .putValue("clientId", "myClient")
             .putValue("subbrand", "myBrand")
             .putValue("playbackPosition", 0)
             .putValue("title", "Helmet Ad");
 
     ValueMap adMetadata = new ValueMap() //
-            .putValue("assetId", 4311)
+            .putValue("assetId", "4311")
             .putValue("type", "pre-roll")
             .putValue("title", "Helmet Ad");
 
@@ -591,10 +591,9 @@ public class NielsenDCRTest {
         .putValue("segB", "segmentB");
 
     ValueMap adMetadata = new ValueMap() //
-        .putValue("customAdAssetId", 4311)
+        .putValue("customAdAssetId", "4311")
             .putValue("type", "pre-roll")
-          .putValue("title", "Helmet Ad")
-            .putValue("title", "Helmet Ad");
+          .putValue("title", "Helmet Ad");
 
     Properties trackProperties = new Properties();
     trackProperties.putAll(adMetadata);

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -134,7 +134,7 @@ public class NielsenDCRTest {
             .putValue("adType", "mid-roll")
             .putValue("totalLength", 100)
             .putValue("videoPlayer", "vimeo")
-            .putValue("playbackPosition", 10)
+            .putValue("position", 10)
             .putValue("fullScreen", true)
             .putValue("bitrate", 50)
             .putValue("sound", 80))
@@ -165,7 +165,7 @@ public class NielsenDCRTest {
                     .putValue("subbrand", "myBrand")
                     .putValue("fullEpisode", true)
                     .putValue("podId", "segment A")
-                    .putValue("playbackPosition", 70)
+                    .putValue("position", 70)
                     .putValue("totalLength", 1200)
                     .putValue("loadType", "dynamic")
                     .putValue("airdate", "2019-08-27T17:00:00Z"))
@@ -220,7 +220,7 @@ public class NielsenDCRTest {
                     .putValue("customSubbrand", "myBrand")
                     .putValue("fullEpisode", true)
                     .putValue("podId", "segment A")
-                    .putValue("playbackPosition", 70)
+                    .putValue("position", 70)
                     .putValue("customLength", 1200)
                     .putValue("totalLength", 1100)
                     .putValue("airdate", "2019-08-27T17:00:00Z"))
@@ -265,7 +265,7 @@ public class NielsenDCRTest {
                     .putValue("publisher", "Turner Broadcasting System")
                     .putValue("fullEpisode", true)
                     .putValue("podId", "segment A")
-                    .putValue("playbackPosition", 70)
+                    .putValue("position", 70)
                     .putValue("airdate", "2019-08-27"))
                     .integration("nielsen-dcr", nielsenOptions)
                     .build());
@@ -309,7 +309,7 @@ public class NielsenDCRTest {
                     .putValue("subbrand", "myBrand")
                     .putValue("fullEpisode", true)
                     .putValue("podId", "segment A")
-                    .putValue("playbackPosition", 70)
+                    .putValue("position", 70)
                     .putValue("totalLength", 1200)
                     .putValue("airdate", date))
                     .integration("nielsen-dcr", nielsenOptions)
@@ -348,7 +348,7 @@ public class NielsenDCRTest {
                     .putValue("publisher", "Turner Broadcasting System")
                     .putValue("fullEpisode", true)
                     .putValue("podId", "segment A")
-                    .putValue("playbackPosition", 70)
+                    .putValue("position", 70)
                     .putValue("totalLength", 1200)
                     .putValue("airdate", "what"))
                     .build());
@@ -389,7 +389,7 @@ public class NielsenDCRTest {
                     .putValue("subbrand", "myBrand")
                     .putValue("fullEpisode", true)
                     .putValue("podId", "segment A")
-                    .putValue("playbackPosition", 70)
+                    .putValue("position", 70)
                     .putValue("totalLength", 1200)
                     .putValue("load_type", "dynamic")
                     .putValue("airdate", "2019-08-27T17:00:00Z"))
@@ -424,7 +424,7 @@ public class NielsenDCRTest {
             .putValue("adType", "post-roll")
             .putValue("totalLength", 100)
             .putValue("videoPlayer", "youtube")
-            .putValue("playbackPosition", 60)
+            .putValue("position", 60)
             .putValue("fullScreen", true)
             .putValue("bitrate", 500)
             .putValue("sound", 80)).build());
@@ -445,7 +445,7 @@ public class NielsenDCRTest {
             .putValue("podId", "adSegmentA")
             .putValue("type", "mid-roll")
             .putValue("totalLength", 120)
-            .putValue("playbackPosition", 0)
+            .putValue("position", 0)
             .putValue("title", "Helmet Ad")).build());
 
     JSONObject expected = new JSONObject();
@@ -467,7 +467,7 @@ public class NielsenDCRTest {
                     .putValue("podId", "adSegmentA")
                     .putValue("type", "mid-roll")
                     .putValue("totalLength", 120)
-                    .putValue("playbackPosition", 0)
+                    .putValue("position", 0)
                     .putValue("title", "Helmet Ad")).build());
 
     JSONObject expected = new JSONObject();
@@ -490,7 +490,7 @@ public class NielsenDCRTest {
             .putValue("loadType", "linear")
             .putValue("position", 20)
             .putValue("contentAssetId", 1234)
-            .putValue("playbackPosition", 0)
+            .putValue("position", 0)
             .putValue("title", "Helmet Ad")).build());
 
     JSONObject adExpected = new JSONObject();
@@ -516,7 +516,7 @@ public class NielsenDCRTest {
             .putValue("contentAssetId", "1234")
             .putValue("clientId", "myClient")
             .putValue("subbrand", "myBrand")
-            .putValue("playbackPosition", 0)
+            .putValue("position", 0)
             .putValue("title", "Helmet Ad");
 
     ValueMap adMetadata = new ValueMap() //
@@ -584,7 +584,7 @@ public class NielsenDCRTest {
         .putValue("customClientId", "myClient")
         .putValue("subbrand", "badBrand")
         .putValue("customSubbrand", "myBrand")
-        .putValue("playbackPosition", 0)
+        .putValue("position", 0)
         .putValue("title", "Helmet Ad")
         .putValue("hasAds", "1")
         .putValue("segB", "segmentB");
@@ -640,7 +640,7 @@ public class NielsenDCRTest {
             .putValue("podId", "adSegmentb")
             .putValue("type", "mid-roll")
             .putValue("totalLength", 100)
-            .putValue("playbackPosition", 100)
+            .putValue("position", 100)
             .putValue("title", "Helmet Ad")).build());
 
     verify(nielsen).stop();


### PR DESCRIPTION
https://segment.atlassian.net/browse/DEST-1240
* This PR should not require a CC ticket, as our mobile SDKs are isolated from production services by their very nature.

**What does this PR do?**
- This PR implements a few Nielsen-requested tweaks, in addition to supporting `Video Playback Seek Started`, `Video Playback Buffer Started`, and `Video Playback Buffer Completed`.
- In addition, this PR hard codes the value of `sfcode` to "DCR" per a request from Nielsen.

**Are there breaking changes in this PR?**
- No.

**Any background context you want to provide?**
- n/a

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
- Yes, there will be parity amongst Web, iOS and Android after implementing Nielsen's requested updates. All platforms should be updated in the same week (week of October 14).

**Does this require a new integration setting? If so, please explain how the new setting works**
- n/a

**Links to helpful docs and other external resources**
- n/a