### PR TITLE
Update Livestream to Fallback to Current Time based off Setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.3.1 / 2020-05-19
+==================
+  * Updates `getPlayheadPosition` to set the `playheadPosition` to the `currentTime` when the new setting `sendCurrentTimeLivestream` is enabled on livestream videos.
+
 1.3.0 / 2019-10-18
 ==================
 
@@ -58,7 +62,7 @@
   * Update/java fmt plugin (#3)
   * Update android-sdk license (#2)
   * Prepare next development version.
-  
+
 1.0.0-beta / 2017-09-13
 ===================================
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=1.3.0-SNAPSHOT
+VERSION=1.3.1-SNAPSHOT
 
 POM_ARTIFACT_ID=nielsendcr
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -133,7 +133,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     if (playheadTimer != null) {
       return;
     }
-    playheadPosition = getPlayheadPosition(properties);
+    playheadPosition = getPlayheadPosition(properties, this.settings);
     playheadTimer = new Timer();
     monitorHeadPos =
         new TimerTask() {
@@ -162,9 +162,10 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     }
   }
 
-  private long getPlayheadPosition(@NonNull ValueMap properties) {
+  private long getPlayheadPosition(@NonNull ValueMap properties,@NonNull ValueMap settings ) {
     int playheadPosition = properties.getInt("position", 0);
     boolean isLiveStream = properties.getBoolean("livestream", false);
+    boolean fallbackToCurrentTime = settings.getBoolean("sendCurrentTimeLivestream", false);
 
     if (!isLiveStream) {
       return playheadPosition;
@@ -172,7 +173,11 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
 
     Calendar calendar = Calendar.getInstance();
     long millis = calendar.getTimeInMillis();
-    long utcTime = TimeUnit.MILLISECONDS.toSeconds(millis) + playheadPosition;
+    if (settings.getBoolean("sendCurrentTimeLivestream")){
+        long utcTime = TimeUnit.MILLISECONDS.toSeconds(millis);
+    } else {
+        long utcTime = TimeUnit.MILLISECONDS.toSeconds(millis) + playheadPosition;
+    }
     return utcTime;
   }
 

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -123,7 +123,6 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
       subbrandPropertyName = null;
       contentLengthPropertyName = null;
     }
-
   }
 
   NielsenDCRIntegration(AppSdk appSdk, Settings settings, Logger logger) {
@@ -175,12 +174,12 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
 
     Calendar calendar = Calendar.getInstance();
     long millis = calendar.getTimeInMillis();
-    if (settings.sendCurrentTimeLivestream){
-        long currentUtcTime = TimeUnit.MILLISECONDS.toSeconds(millis);
-        return currentUtcTime;
+    if (settings.sendCurrentTimeLivestream) {
+      long currentUtcTime = TimeUnit.MILLISECONDS.toSeconds(millis);
+      return currentUtcTime;
     } else {
-        long utcOffsetTime = TimeUnit.MILLISECONDS.toSeconds(millis) + playheadPosition;
-        return utcOffsetTime;
+      long utcOffsetTime = TimeUnit.MILLISECONDS.toSeconds(millis) + playheadPosition;
+      return utcOffsetTime;
     }
   }
 


### PR DESCRIPTION
1. add new setting sendCurrentTimeLivestream
2. updates returnPlayheadPosition to check if setting is enabled. When video is livestream and setting enabled to only set playhead position to current time.

NOTE: Unit tests broken for this repo because RoboElectric requires Java 9 which is unsupported by Android. These changes are minimal and only being used/tested by Fox on dev sources. 