### PR TITLE
update event mappings, allow airdate with ms and add new section setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ dependencies {
         // values to global gradle.properties file
         // values to global gradle.properties file
         // See https://engineeringportal.nielsen.com/docs/Digital_Measurement_Android_Artifactory_Guide
-          username = NIELSEN_USER
-          password = NIELSEN_AUTHCODE
+        username = NIELSEN_USER
+        password = NIELSEN_AUTHCODE
       }
       authentication {
         basic(BasicAuthentication)

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ dependencies {
         // values to global gradle.properties file
         // values to global gradle.properties file
         // See https://engineeringportal.nielsen.com/docs/Digital_Measurement_Android_Artifactory_Guide
-        username = NIELSEN_USER
-        password = NIELSEN_AUTHCODE
+          username = NIELSEN_USER
+          password = NIELSEN_AUTHCODE
       }
       authentication {
         basic(BasicAuthentication)
@@ -75,8 +75,11 @@ dependencies {
   testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.skyscreamer:jsonassert:1.5.0'
-  testImplementation 'org.robolectric:robolectric:4.3'
+  testImplementation 'org.robolectric:robolectric:4.5'
   testImplementation 'org.mockito:mockito-core:2.28.0'
+  testImplementation 'net.bytebuddy:byte-buddy:1.9.10'
+  testImplementation 'org.objenesis:objenesis:3.0.1'
+  implementation group: 'androidx.lifecycle', name: 'lifecycle-common-java8', version: '2.3.0'
 
   // Required for local (non-android) testing
   testImplementation 'org.json:json:20180813'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=1.3.2-SNAPSHOT
+VERSION=1.4.0-SNAPSHOT
 
 POM_ARTIFACT_ID=nielsendcr
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -452,7 +452,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     }
 
     switch (event) {
-      // Nielsen requires we load content metadata and call play upon playback start
+        // Nielsen requires we load content metadata and call play upon playback start
       case "Video Playback Started":
         appSdk.loadMetadata(contentMetadata);
         logger.verbose("appSdk.loadMetadata(%s)", contentMetadata);
@@ -600,9 +600,9 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
   public void screen(ScreenPayload screen) {
     String name;
     if (settings.customSectionProperty != null) {
-       name = screen.properties().getString(settings.customSectionProperty);
+      name = screen.properties().getString(settings.customSectionProperty);
     } else {
-       name = screen.name();
+      name = screen.name();
     }
     JSONObject metadata = new JSONObject();
 

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -566,6 +566,8 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
       case "Video Playback Buffer Started":
       case "Video Playback Buffer Completed":
       case "Video Playback Resumed":
+      case "Video Playback Exited":
+      case "Video Playback Completed":
         try {
           trackVideoPlayback(track, properties, nielsenOptions);
         } catch (JSONException e) {
@@ -597,7 +599,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
   public void screen(ScreenPayload screen) {
     String name;
     if (settings.customSectionProperty != null) {
-       name = properties.getString(settings.customSectionProperty);
+       name = screen.properties().getString(settings.customSectionProperty);
     } else {
        name = screen.name();
     }

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegrationFactory.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegrationFactory.java
@@ -97,12 +97,14 @@ class NielsenDCRIntegrationFactory implements Integration.Factory {
       if (subbrandPropertyName != null && !subbrandPropertyName.isEmpty()) {
         integrationSettings.subbrandPropertyName = subbrandPropertyName;
       }
-
       String contentLengthPropertyName = settings.getString("contentLengthPropertyName");
       if (contentLengthPropertyName != null && !contentLengthPropertyName.isEmpty()) {
         integrationSettings.contentLengthPropertyName = contentLengthPropertyName;
       }
-
+      String customSectionProperty = settings.getString("customSectionProperty");
+      if (customSectionProperty != null && !customSectionProperty.isEmpty()) {
+        integrationSettings.customSectionProperty = customSectionProperty;
+      }
       Boolean sendCurrentTimeLivestream = settings.getBoolean("sendCurrentTimeLivestream", false);
       integrationSettings.sendCurrentTimeLivestream = sendCurrentTimeLivestream;
 

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -164,8 +164,31 @@ public class NielsenDCRTest {
             .integration("nielsen-dcr", nielsenOptions)
             .build());
 
-    verify(nielsen).end();
+    verify(nielsen).stop();
   }
+
+    @Test
+    public void videoPlaybackExited() {
+
+        Map<String, Object> nielsenOptions = new LinkedHashMap<>();
+        nielsenOptions.put("channelName", "exampleChannelName");
+
+        integration.track(new TrackPayload.Builder().anonymousId("foo") //
+                .event("Video Playback Exited")
+                .properties(new Properties() //
+                        .putValue("assetId", 1234)
+                        .putValue("adType", "mid-roll")
+                        .putValue("totalLength", 100)
+                        .putValue("videoPlayer", "vimeo")
+                        .putValue("position", 10)
+                        .putValue("fullScreen", true)
+                        .putValue("bitrate", 50)
+                        .putValue("sound", 80))
+                .integration("nielsen-dcr", nielsenOptions)
+                .build());
+
+        verify(nielsen).stop();
+    }
 
   @Test
   public void videoContentStarted() throws JSONException {
@@ -191,7 +214,7 @@ public class NielsenDCRTest {
                     .putValue("position", 70)
                     .putValue("totalLength", 1200)
                     .putValue("loadType", "dynamic")
-                    .putValue("airdate", "2019-08-27T17:00:00Z"))
+                    .putValue("airdate", "2019-08-27T17:00:00.000Z"))
                     .integration("nielsen-dcr", nielsenOptions)
                     .build());
 
@@ -688,6 +711,8 @@ public class NielsenDCRTest {
   @Test
   public void screenWithOptions() throws JSONException {
 
+    settings.customSectionProperty = "customSectionName";
+
     Map<String, Object> nielsenOptions = new LinkedHashMap<>();
     nielsenOptions.put("segB", "segmentB");
     nielsenOptions.put("segC", "segmentC");
@@ -700,7 +725,7 @@ public class NielsenDCRTest {
             .build());
 
     JSONObject expected = new JSONObject();
-    expected.put("name", "Home");
+    expected.put("name", "customSectionName");
     expected.put("type", "static");
     expected.put("segB", "segmentB");
     expected.put("segC", "segmentC");
@@ -708,6 +733,7 @@ public class NielsenDCRTest {
 
     verify(nielsen).loadMetadata(jsonEq(expected));
   }
+
 
   /**
    * Uses the string representation of the object. Useful for JSON objects.

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -190,6 +190,29 @@ public class NielsenDCRTest {
         verify(nielsen).stop();
     }
 
+    @Test
+    public void videoPlaybackCompleted() {
+
+        Map<String, Object> nielsenOptions = new LinkedHashMap<>();
+        nielsenOptions.put("channelName", "exampleChannelName");
+
+        integration.track(new TrackPayload.Builder().anonymousId("foo") //
+                .event("Video Playback Completed")
+                .properties(new Properties() //
+                        .putValue("assetId", 1234)
+                        .putValue("adType", "mid-roll")
+                        .putValue("totalLength", 100)
+                        .putValue("videoPlayer", "vimeo")
+                        .putValue("position", 10)
+                        .putValue("fullScreen", true)
+                        .putValue("bitrate", 50)
+                        .putValue("sound", 80))
+                .integration("nielsen-dcr", nielsenOptions)
+                .build());
+
+        verify(nielsen).end();
+    }
+
   @Test
   public void videoContentStarted() throws JSONException {
 
@@ -269,7 +292,7 @@ public class NielsenDCRTest {
                     .putValue("position", 70)
                     .putValue("customLength", 1200)
                     .putValue("totalLength", 1100)
-                    .putValue("airdate", "2019-08-27T17:00:00Z"))
+                    .putValue("airdate", "2019-08-27t17:00:00.000z"))
                     .integration("nielsen-dcr", nielsenOptions)
                     .build());
 
@@ -711,7 +734,7 @@ public class NielsenDCRTest {
   @Test
   public void screenWithOptions() throws JSONException {
 
-    settings.customSectionProperty = "customSectionName";
+    settings.customSectionProperty = "customSection";
 
     Map<String, Object> nielsenOptions = new LinkedHashMap<>();
     nielsenOptions.put("segB", "segmentB");
@@ -720,12 +743,13 @@ public class NielsenDCRTest {
 
     integration.screen(
         new ScreenPayload.Builder().anonymousId("foo").name("Home").properties(new Properties() //
-            .putValue("variation", "blue sign up button"))
+            .putValue("variation", "blue sign up button")
+            .putValue("customSection", "mySection"))
             .integration("nielsen-dcr", nielsenOptions)
             .build());
 
     JSONObject expected = new JSONObject();
-    expected.put("name", "customSectionName");
+    expected.put("name", "mySection");
     expected.put("type", "static");
     expected.put("segB", "segmentB");
     expected.put("segC", "segmentC");


### PR DESCRIPTION
**What does this PR do?**
Nielsen has requested we make the following changes to event mappings:

- Update mapping for Video Playback Interrupted to call `stop` instead of `end`
- Add mapping for Video Playback Exited to call `stop`. Context: Fox has requested a new event for Video Playback Exited be added to our spec. This has been approved by the spec committee. See here: https://paper.dropbox.com/doc/Video-Spec-Event-Proposal-for-Video-Playback-Exited--A8j5DFZuVoZYlsG~ZQr96tlcAg-rUDm4tQEB1RsdH0R7Xujm. 
- Update airdate formatter to detect ISO timestamp with milliseconds and format to meet Nielsen's spec
- Update mapping for Video Playback Started to call `play` and load content metadata
- Add UI setting for "Custom Screen/Page Section Property Name" to allow customers to use a different property as the screen section sent to Nielsen. New mapping first checks for this setting and then if it doesn't exist, fallback on screen name. UI setting added to partner portal in `app.segment.build` as `customSectionProperty`.

**Testing**
Unit tests are erroring out with the following message:

`org.mockito.exceptions.base.MockitoException:`
`Mockito cannot mock this class: class com.nielsen.app.sdk.AppSdk.`

![Screen Shot 2021-02-11 at 6 14 37 PM](https://user-images.githubusercontent.com/49517136/107723061-7dbaee00-6c9d-11eb-94bf-3f0342f6d24a.png)

This error happens on the `master` branch as well so I wonder if the Nielsen AppSdk is a private and/or final class. Working on resolving unit tests and testing locally.

Changes being made for iOS and web as well. iOS PR here: https://github.com/segment-integrations/analytics-ios-integration-nielsen-dcr/pull/25