### PR TITLE
Add livestream setting to factory and update build.gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.3.2 / 2021-03-26
+==================
+  * Add `sendCurrentTimeLivestream` setting to instantiation code in `NielsenDCRIntegrationFactory`.
+  * Add fallback to `false` for `sendCurrentTimeLivestream` setting.
+  * Add unit test for "Video Playback Started" for livestream videos.
+  * Update build dependencies.
+
 1.3.1 / 2020-05-19
 ==================
   * Updates `getPlayheadPosition` to set the `playheadPosition` to the `currentTime` when the new setting `sendCurrentTimeLivestream` is enabled on livestream videos.

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ dependencies {
         // values to global gradle.properties file
         // values to global gradle.properties file
         // See https://engineeringportal.nielsen.com/docs/Digital_Measurement_Android_Artifactory_Guide
-          username = NIELSEN_USER
-          password = NIELSEN_AUTHCODE
+        username = NIELSEN_USER
+        password = NIELSEN_AUTHCODE
       }
       authentication {
         basic(BasicAuthentication)
@@ -72,14 +72,14 @@ dependencies {
   api 'com.segment.analytics.android:analytics:4.3.1'
   api 'com.nielsenappsdk:global:[6.2,)'
 
-    testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.skyscreamer:jsonassert:1.5.0'
-    testImplementation 'org.robolectric:robolectric:4.5'
-    testImplementation 'org.mockito:mockito-core:2.28.0'
-    testImplementation 'net.bytebuddy:byte-buddy:1.9.10'
-    testImplementation 'org.objenesis:objenesis:3.0.1'
-    implementation group: 'androidx.lifecycle', name: 'lifecycle-common-java8', version: '2.3.0'
+  testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
+  testImplementation 'junit:junit:4.12'
+  testImplementation 'org.skyscreamer:jsonassert:1.5.0'
+  testImplementation 'org.robolectric:robolectric:4.5'
+  testImplementation 'org.mockito:mockito-core:2.28.0'
+  testImplementation 'net.bytebuddy:byte-buddy:1.9.10'
+  testImplementation 'org.objenesis:objenesis:3.0.1'
+  implementation group: 'androidx.lifecycle', name: 'lifecycle-common-java8', version: '2.3.0'
 
   // Required for local (non-android) testing
   testImplementation 'org.json:json:20180813'

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ dependencies {
         // values to global gradle.properties file
         // values to global gradle.properties file
         // See https://engineeringportal.nielsen.com/docs/Digital_Measurement_Android_Artifactory_Guide
-        username = NIELSEN_USER
-        password = NIELSEN_AUTHCODE
+          username = NIELSEN_USER
+          password = NIELSEN_AUTHCODE
       }
       authentication {
         basic(BasicAuthentication)
@@ -72,11 +72,14 @@ dependencies {
   api 'com.segment.analytics.android:analytics:4.3.1'
   api 'com.nielsenappsdk:global:[6.2,)'
 
-  testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
-  testImplementation 'junit:junit:4.12'
-  testImplementation 'org.skyscreamer:jsonassert:1.5.0'
-  testImplementation 'org.robolectric:robolectric:4.3'
-  testImplementation 'org.mockito:mockito-core:2.28.0'
+    testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.skyscreamer:jsonassert:1.5.0'
+    testImplementation 'org.robolectric:robolectric:4.5'
+    testImplementation 'org.mockito:mockito-core:2.28.0'
+    testImplementation 'net.bytebuddy:byte-buddy:1.9.10'
+    testImplementation 'org.objenesis:objenesis:3.0.1'
+    implementation group: 'androidx.lifecycle', name: 'lifecycle-common-java8', version: '2.3.0'
 
   // Required for local (non-android) testing
   testImplementation 'org.json:json:20180813'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=1.3.1-SNAPSHOT
+VERSION=1.3.2-SNAPSHOT
 
 POM_ARTIFACT_ID=nielsendcr
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -122,6 +122,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
       clientIdPropertyName = null;
       subbrandPropertyName = null;
       contentLengthPropertyName = null;
+      sendCurrentTimeLivestream = false;
     }
   }
 

--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegrationFactory.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegrationFactory.java
@@ -103,6 +103,9 @@ class NielsenDCRIntegrationFactory implements Integration.Factory {
         integrationSettings.contentLengthPropertyName = contentLengthPropertyName;
       }
 
+      Boolean sendCurrentTimeLivestream = settings.getBoolean("sendCurrentTimeLivestream", false);
+      integrationSettings.sendCurrentTimeLivestream = sendCurrentTimeLivestream;
+
       return new NielsenDCRIntegration(appSdk, integrationSettings, logger);
     } catch (JSONException e) {
       logger.error(e, "Could not initialize settings.");

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -122,6 +122,26 @@ public class NielsenDCRTest {
   }
 
   @Test
+  public void videoPlaybackStarted_livestream() throws JSONException {
+    integration.track(
+        new TrackPayload.Builder().anonymousId("foo").event("Video Playback Started").properties(new Properties() //
+            .putValue("assetId", 1234)
+            .putValue("adType", "pre-roll")
+            .putValue("totalLength", 120)
+            .putValue("videoPlayer", "youtube")
+            .putValue("sound", 80)
+            .putValue("bitrate", 40)
+            .putValue("livestream", true)
+            .putValue("fullScreen", true)).build());
+
+    JSONObject expected = new JSONObject();
+    expected.put("channelName", "defaultChannelName");
+    expected.put("mediaURL", "");
+
+    verify(nielsen).play(jsonEq(expected));
+  }
+
+  @Test
   public void videoPlaybackPaused() {
 
     Map<String, Object> nielsenOptions = new LinkedHashMap<>();


### PR DESCRIPTION
Fox found a bug with a setting we added last May: https://github.com/segment-integrations/analytics-android-integration-nielsen-dcr/commit/7b2007a2c4a4d95391b0f3013a468be5c7c80f82. Specifically, when a live video (`livestream = true`) plays their app will crash because the `sendCurrentTimeLivestream` setting was not given a default value and is not in the `IntegrationFactory` settings. It crashes with the following error, which I was able to replicate:

![Screen Shot 2021-03-25 at 3 39 28 PM](https://user-images.githubusercontent.com/49517136/112554196-18214d80-8d83-11eb-8f5d-48fd47bd49ec.png)

A unit test was not added for `livestream = true` so we did not catch this originally. I added a unit test for `videoPlaybackStarted_livestream` and ran it against the master branch. The test failed with the same error:
![Screen Shot 2021-03-25 at 3 47 08 PM](https://user-images.githubusercontent.com/49517136/112554250-2d967780-8d83-11eb-8d60-7eae7b14d03e.png)

We can resolve the crash by adding a default value of `false` for this setting to the integration code. Doing so results in the unit test passing because it is assigned a boolean value (as opposed to `null` previously):
![Screen Shot 2021-03-25 at 3 51 25 PM](https://user-images.githubusercontent.com/49517136/112554362-60d90680-8d83-11eb-99fc-4896c87d5b3f.png)

Resolving the crash is not enough though, since we also need to make the setting available in IntegrationFactory. I have added that change to the factory file.

Lastly, I updated our build.gradle file since we discovered that dependencies were missing that were needed for unit tests to work. This was done in [another open PR](https://github.com/segment-integrations/analytics-android-integration-nielsen-dcr/pull/19) (that has not been merged yet - less urgent), but it would be better if we could merge them into master sooner rather later which is why I made the changes in this PR. 

I'm hoping this PR can be merged and new version released ASAP as this is a blocker to Fox using the Nielsen DCR integration on Android. The last step will be testing this locally, but I may need assistance generating a new snapshot or generating a .jar file that I can add to my test app. @prayansh helped with this previously so I will reach out to him now!