### PR TITLE
Allow setting custom assetId for screen events

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRIntegration.java
@@ -278,14 +278,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     }
 
     // map settings to Nielsen content metadata fields
-    String contentAssetId;
-    if (settings.contentAssetIdPropertyName != null) {
-      contentAssetId = properties.getString(settings.contentAssetIdPropertyName);
-    } else if (properties.getString("assetId") != null) {
-      contentAssetId = properties.getString("assetId");
-    } else {
-      contentAssetId = properties.getString("contentAssetId");
-    }
+    String contentAssetId = fetchContentAssetId(properties);
     contentMetadata.put("assetid", contentAssetId);
 
     String clientIdPropertyName =
@@ -612,9 +605,22 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     return sectionProperty;
   }
 
+  private String fetchContentAssetId(@NonNull ValueMap properties) {
+    String contentAssetId;
+    if (settings.contentAssetIdPropertyName != null) {
+      contentAssetId = properties.getString(settings.contentAssetIdPropertyName);
+    } else if (properties.getString("assetId") != null) {
+      contentAssetId = properties.getString("assetId");
+    } else {
+      contentAssetId = properties.getString("contentAssetId");
+    }
+    return contentAssetId;
+  }
+
   @Override
   public void screen(ScreenPayload screen) {
     String name = fetchSectionProperty(screen.properties(), screen.name());
+    String contentAssetId = fetchContentAssetId(screen.properties());
 
     JSONObject metadata = new JSONObject();
 
@@ -626,6 +632,7 @@ public class NielsenDCRIntegration extends Integration<AppSdk> {
     try {
       metadata.put("section", name);
       metadata.put("type", "static");
+      metadata.put("assetid", contentAssetId);
 
       // segB and segC are required values, so will send a default value
       if (nielsenOptions.containsKey("segB")) {

--- a/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/nielsendcr/NielsenDCRTest.java
@@ -739,11 +739,17 @@ public class NielsenDCRTest {
   public void screen() throws JSONException {
 
     integration.screen(
-            new ScreenPayload.Builder().anonymousId("foo").name("Home").properties(new Properties() //
-            .putValue("variation", "blue sign up button"))
+        new ScreenPayload.Builder()
+            .anonymousId("foo")
+            .name("Home")
+            .properties(new Properties() //
+                .putValue("variation", "blue sign up button")
+                .putValue("assetId", 1234)
+            )
             .build());
     JSONObject expected = new JSONObject();
     expected.put("section", "Home");
+    expected.put("assetid", "1234");
     expected.put("type", "static");
     expected.put("segB", "");
     expected.put("segC", "");
@@ -755,6 +761,7 @@ public class NielsenDCRTest {
   public void screenWithOptions() throws JSONException {
 
     settings.customSectionProperty = "customSection";
+    settings.contentAssetIdPropertyName = "customContentAssetId";
 
     Map<String, Object> nielsenOptions = new LinkedHashMap<>();
     nielsenOptions.put("segB", "segmentB");
@@ -762,9 +769,14 @@ public class NielsenDCRTest {
     nielsenOptions.put("crossId1", "crossIdValue");
 
     integration.screen(
-        new ScreenPayload.Builder().anonymousId("foo").name("Home").properties(new Properties() //
-            .putValue("variation", "blue sign up button")
-            .putValue("customSection", "mySection"))
+        new ScreenPayload.Builder()
+            .anonymousId("foo")
+            .name("Home")
+            .properties(new Properties() //
+                .putValue("variation", "blue sign up button")
+                .putValue("customSection", "mySection")
+                .putValue("customContentAssetId", 1234)
+            )
             .integration("nielsen-dcr", nielsenOptions)
             .build());
 
@@ -774,6 +786,7 @@ public class NielsenDCRTest {
     expected.put("segB", "segmentB");
     expected.put("segC", "segmentC");
     expected.put("crossId1", "crossIdValue");
+    expected.put("assetid", "1234");
 
     verify(nielsen).loadMetadata(jsonEq(expected));
   }


### PR DESCRIPTION
Users can now pass in assetId for screen events just like they do for track events